### PR TITLE
[AP-3440] Change module org to trustero

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To see what functionality is available in the current API client release, please
 ## Usage
 
 ```go
-import  jamf "github.com/intersticelabs/jamf-api-client-go/classic"
+import  jamf "github.com/trustero/jamf-api-client-go/classic"
 
 // You can optionally setup a custom HTTP client to use which can
 // include any settings you desire. If you would like to use the 

--- a/classic/client/client_test.go
+++ b/classic/client/client_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/intersticelabs/jamf-api-client-go/classic/client"
+	jamf "github.com/trustero/jamf-api-client-go/classic/client"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/classic/client/client_test.go
+++ b/classic/client/client_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/trustero/jamf-api-client-go/classic/client"
 	"github.com/stretchr/testify/assert"
+	jamf "github.com/trustero/jamf-api-client-go/classic/client"
 )
 
 type MockResponse struct {

--- a/classic/client_test.go
+++ b/classic/client_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/trustero/jamf-api-client-go/classic"
 	"github.com/stretchr/testify/assert"
+	jamf "github.com/trustero/jamf-api-client-go/classic"
 )
 
 type MockResponse struct {

--- a/classic/client_test.go
+++ b/classic/client_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/intersticelabs/jamf-api-client-go/classic"
+	jamf "github.com/trustero/jamf-api-client-go/classic"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/classic/computerextensionattributes/client.go
+++ b/classic/computerextensionattributes/client.go
@@ -1,7 +1,7 @@
 package computerextensionattributes
 
 import (
-	"github.com/intersticelabs/jamf-api-client-go/classic/client"
+	"github.com/trustero/jamf-api-client-go/classic/client"
 	"net/http"
 )
 

--- a/classic/computerextensionattributes/computer_extension_attr.go
+++ b/classic/computerextensionattributes/computer_extension_attr.go
@@ -5,8 +5,8 @@ package computerextensionattributes
 
 import (
 	"context"
-	"github.com/trustero/jamf-api-client-go/classic/client"
 	"github.com/pkg/errors"
+	"github.com/trustero/jamf-api-client-go/classic/client"
 	"net/http"
 )
 

--- a/classic/computerextensionattributes/computer_extension_attr.go
+++ b/classic/computerextensionattributes/computer_extension_attr.go
@@ -5,7 +5,7 @@ package computerextensionattributes
 
 import (
 	"context"
-	"github.com/intersticelabs/jamf-api-client-go/classic/client"
+	"github.com/trustero/jamf-api-client-go/classic/client"
 	"github.com/pkg/errors"
 	"net/http"
 )

--- a/classic/computerextensionattributes/computer_extension_attr_test.go
+++ b/classic/computerextensionattributes/computer_extension_attr_test.go
@@ -12,7 +12,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/intersticelabs/jamf-api-client-go/classic/computerextensionattributes"
+	jamf "github.com/trustero/jamf-api-client-go/classic/computerextensionattributes"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/classic/computerextensionattributes/computer_extension_attr_test.go
+++ b/classic/computerextensionattributes/computer_extension_attr_test.go
@@ -12,8 +12,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/trustero/jamf-api-client-go/classic/computerextensionattributes"
 	"github.com/stretchr/testify/assert"
+	jamf "github.com/trustero/jamf-api-client-go/classic/computerextensionattributes"
 )
 
 var COMPUTER_EXT_ATTR_API_BASE_ENDPOINT = "/JSSResource/computerextensionattributes"

--- a/classic/computers/client.go
+++ b/classic/computers/client.go
@@ -1,7 +1,7 @@
 package computers
 
 import (
-	"github.com/intersticelabs/jamf-api-client-go/classic/client"
+	"github.com/trustero/jamf-api-client-go/classic/client"
 	"net/http"
 )
 

--- a/classic/computers/computer.go
+++ b/classic/computers/computer.go
@@ -6,7 +6,7 @@ package computers
 import (
 	"context"
 	"fmt"
-	"github.com/intersticelabs/jamf-api-client-go/classic/client"
+	"github.com/trustero/jamf-api-client-go/classic/client"
 	"net/http"
 
 	"github.com/pkg/errors"

--- a/classic/computers/computer_entity.go
+++ b/classic/computers/computer_entity.go
@@ -77,18 +77,18 @@ type HardwareInformation struct {
 	ServicePack                 string    `json:"service_pack"`
 	ProcessorType               string    `json:"processor_type"`
 	ProcessorArchitecture       string    `json:"processor_architecture"`
-	ProcessorSpeed              int      `json:"processor_speed"`
-	ProcessorSpeedMhz           int      `json:"processor_speed_mhz"`
-	NumberProcessors            int      `json:"number_processors"`
-	NumberCores                 int      `json:"number_cores"`
-	TotalRam                    int64    `json:"total_ram"`
-	TotalRamMb                  int64    `json:"total_ram_mb"`
+	ProcessorSpeed              int       `json:"processor_speed"`
+	ProcessorSpeedMhz           int       `json:"processor_speed_mhz"`
+	NumberProcessors            int       `json:"number_processors"`
+	NumberCores                 int       `json:"number_cores"`
+	TotalRam                    int64     `json:"total_ram"`
+	TotalRamMb                  int64     `json:"total_ram_mb"`
 	BootRom                     string    `json:"boot_rom"`
-	BusSpeed                    int      `json:"bus_speed"`
-	BusSpeedMhz                 int      `json:"bus_speed_mhz"`
-	BatteryCapacity             int      `json:"battery_capacity"`
-	CacheSize                   int64    `json:"cache_size"`
-	CacheSizeKb                 int64    `json:"cache_size_kb"`
+	BusSpeed                    int       `json:"bus_speed"`
+	BusSpeedMhz                 int       `json:"bus_speed_mhz"`
+	BatteryCapacity             int       `json:"battery_capacity"`
+	CacheSize                   int64     `json:"cache_size"`
+	CacheSizeKb                 int64     `json:"cache_size_kb"`
 	SIPStatus                   string    `json:"sip_status"`
 	GatekeeperStatus            string    `json:"gatekeeper_status"`
 	XProtectVersion             string    `json:"xprotect_version"`
@@ -107,8 +107,8 @@ type Device struct {
 	Model           string      `json:"model"`
 	Revision        string      `json:"revision"`
 	SerialNumber    string      `json:"serial_number"`
-	Size            int64      `json:"size"`
-	DriveCapacityMB int64      `json:"drive_capacity_mb"`
+	Size            int64       `json:"size"`
+	DriveCapacityMB int64       `json:"drive_capacity_mb"`
 	ConnectionType  string      `json:"connection_type"`
 	SmartStatus     string      `json:"smart_status"`
 	Partition       []Partition `json:"partition"`
@@ -117,13 +117,13 @@ type Partition struct {
 	Name                 string `json:"name"`
 	Size                 int64  `json:"size"`
 	PartitionType        string `json:"type"`
-	PartitionCapacityMB  int64 `json:"partition_capacity_mb"`
-	PercentageFull       int   `json:"percentage_full"`
+	PartitionCapacityMB  int64  `json:"partition_capacity_mb"`
+	PercentageFull       int    `json:"percentage_full"`
 	FilevaultStatus      string `json:"filevault_status"`
-	FilevaultPercent     int   `json:"filevault_percent"`
+	FilevaultPercent     int    `json:"filevault_percent"`
 	Filevault2Status     string `json:"filevault2_status"`
-	Filevaul2tPercent    int   `json:"filevault2_percent"`
-	BootDriveAvailableMB int64 `json:"boot_drive_available_mb"`
+	Filevaul2tPercent    int    `json:"filevault2_percent"`
+	BootDriveAvailableMB int64  `json:"boot_drive_available_mb"`
 	LvgUUID              string `json:"lvg_uuid"`
 	LvUUID               string `json:"lv_uuid"`
 	PvUUID               string `json:"pv_uuid"`

--- a/classic/computers/computer_test.go
+++ b/classic/computers/computer_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/intersticelabs/jamf-api-client-go/classic/computers"
+	jamf "github.com/trustero/jamf-api-client-go/classic/computers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/classic/computers/computer_test.go
+++ b/classic/computers/computer_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/trustero/jamf-api-client-go/classic/computers"
 	"github.com/stretchr/testify/assert"
+	jamf "github.com/trustero/jamf-api-client-go/classic/computers"
 )
 
 var COMPUTER_API_BASE_ENDPOINT = "/JSSResource/computers"

--- a/classic/policies/client.go
+++ b/classic/policies/client.go
@@ -6,6 +6,7 @@ import (
 )
 
 const domain = "policies"
+
 type Service struct {
 	client *client.Client
 }

--- a/classic/policies/client.go
+++ b/classic/policies/client.go
@@ -1,7 +1,7 @@
 package policies
 
 import (
-	"github.com/intersticelabs/jamf-api-client-go/classic/client"
+	"github.com/trustero/jamf-api-client-go/classic/client"
 	"net/http"
 )
 

--- a/classic/policies/policy.go
+++ b/classic/policies/policy.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"github.com/intersticelabs/jamf-api-client-go/classic/client"
+	"github.com/trustero/jamf-api-client-go/classic/client"
 	"net/http"
 
 	"github.com/pkg/errors"

--- a/classic/policies/policy_test.go
+++ b/classic/policies/policy_test.go
@@ -13,8 +13,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/trustero/jamf-api-client-go/classic/policies"
 	"github.com/stretchr/testify/assert"
+	jamf "github.com/trustero/jamf-api-client-go/classic/policies"
 )
 
 var POLICIES_API_BASE_ENDPOINT = "/JSSResource/policies"

--- a/classic/policies/policy_test.go
+++ b/classic/policies/policy_test.go
@@ -7,13 +7,13 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/intersticelabs/jamf-api-client-go/classic/computers"
+	"github.com/trustero/jamf-api-client-go/classic/computers"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/intersticelabs/jamf-api-client-go/classic/policies"
+	jamf "github.com/trustero/jamf-api-client-go/classic/policies"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/classic/policies/scope_entity.go
+++ b/classic/policies/scope_entity.go
@@ -3,7 +3,7 @@
 
 package policies
 
-import "github.com/intersticelabs/jamf-api-client-go/classic/computers"
+import "github.com/trustero/jamf-api-client-go/classic/computers"
 
 // Scope represents the scope of a related Jamf configuration setting or Policy
 type Scope struct {

--- a/classic/policies/scope_entity.go
+++ b/classic/policies/scope_entity.go
@@ -7,14 +7,14 @@ import "github.com/trustero/jamf-api-client-go/classic/computers"
 
 // Scope represents the scope of a related Jamf configuration setting or Policy
 type Scope struct {
-	AllComputers   bool                  `json:"all_computers" xml:"all_computers,omitempty"`
-	Computers      []*computers.BasicComputerInfo  `json:"computers" xml:"computers>computer,omitempty"`
-	ComputerGroups []*computers.ComputerGroup      `json:"computer_groups" xml:"computer_groups>computer_group,omitempty"`
-	Buildings      []*Building           `json:"buildings" xml:"buildings,omitempty"`
-	Departments    []*Department         `json:"departments" xml:"departments,omitempty"`
-	LimitToUsers   *UserGroupLimitations `json:"limit_to_users" xml:"limit_to_users,omitempty"`
-	Limitations    *Limitations          `json:"limitations" xml:"limitations,omitempty"`
-	Exclusions     *Exclusions           `json:"exclusions" xml:"exclusions,omitempty"`
+	AllComputers   bool                           `json:"all_computers" xml:"all_computers,omitempty"`
+	Computers      []*computers.BasicComputerInfo `json:"computers" xml:"computers>computer,omitempty"`
+	ComputerGroups []*computers.ComputerGroup     `json:"computer_groups" xml:"computer_groups>computer_group,omitempty"`
+	Buildings      []*Building                    `json:"buildings" xml:"buildings,omitempty"`
+	Departments    []*Department                  `json:"departments" xml:"departments,omitempty"`
+	LimitToUsers   *UserGroupLimitations          `json:"limit_to_users" xml:"limit_to_users,omitempty"`
+	Limitations    *Limitations                   `json:"limitations" xml:"limitations,omitempty"`
+	Exclusions     *Exclusions                    `json:"exclusions" xml:"exclusions,omitempty"`
 }
 
 // Building represents a building configured in Jamf that a setting can be scoped to
@@ -73,9 +73,9 @@ type Limitations struct {
 type Exclusions struct {
 	Computers       []*computers.BasicComputerInfo `json:"computers"`
 	ComputerGroups  []*computers.ComputerGroup     `json:"computer_groups"`
-	Buildings       []*Building          `json:"buildings"`
-	Departments     []*Department        `json:"departments"`
-	Users           []*User              `json:"users"`
-	UserGroups      []*UserGroup         `json:"user_groups"`
-	NetworkSegments []*NetworkSegment    `json:"network_segments"`
+	Buildings       []*Building                    `json:"buildings"`
+	Departments     []*Department                  `json:"departments"`
+	Users           []*User                        `json:"users"`
+	UserGroups      []*UserGroup                   `json:"user_groups"`
+	NetworkSegments []*NetworkSegment              `json:"network_segments"`
 }

--- a/classic/scripts_test.go
+++ b/classic/scripts_test.go
@@ -12,7 +12,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/intersticelabs/jamf-api-client-go/classic"
+	jamf "github.com/trustero/jamf-api-client-go/classic"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/classic/scripts_test.go
+++ b/classic/scripts_test.go
@@ -12,8 +12,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	jamf "github.com/trustero/jamf-api-client-go/classic"
 	"github.com/stretchr/testify/assert"
+	jamf "github.com/trustero/jamf-api-client-go/classic"
 )
 
 var SCRIPTS_API_BASE_ENDPOINT = "/JSSResource/scripts"

--- a/classic/utils.go
+++ b/classic/utils.go
@@ -32,4 +32,3 @@ func EndpointBuilder(endpoint string, context string, identifier interface{}) (s
 	}
 	return ep, nil
 }
-

--- a/classic/utils_test.go
+++ b/classic/utils_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"testing"
 
-	jamf "github.com/trustero/jamf-api-client-go/classic"
 	"github.com/stretchr/testify/assert"
+	jamf "github.com/trustero/jamf-api-client-go/classic"
 )
 
 var testDomain = "https://mock.test.com"

--- a/classic/utils_test.go
+++ b/classic/utils_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	jamf "github.com/intersticelabs/jamf-api-client-go/classic"
+	jamf "github.com/trustero/jamf-api-client-go/classic"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/comp_extension_attrs.go
+++ b/examples/comp_extension_attrs.go
@@ -6,7 +6,7 @@ package main
 //	"os"
 //	"time"
 //
-//	jamf "github.com/intersticelabs/jamf-api-client-go/classic/computerextensionattributes"
+//	jamf "github.com/trustero/jamf-api-client-go/classic/computerextensionattributes"
 //)
 //
 //func checkAndHandleErr(err error) {

--- a/examples/comp_extension_attrs.go
+++ b/examples/comp_extension_attrs.go
@@ -1,4 +1,5 @@
 package main
+
 //
 //import (
 //	"encoding/json"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/intersticelabs/jamf-api-client-go
+module github.com/trustero/jamf-api-client-go
 
 go 1.13
 


### PR DESCRIPTION
# Summary [AP-3440]

- Replace 'intersticelabs' with 'trustero'
- Replace 'intersticelabs' with 'trustero' and run 'make pr-prep'

# Description

Change module org from intersticelabs to trustero.  After this PR is merged, I'll change our github org name to 'trustero'.

# Test

Run 'make test' and observed correctness

# PR
[AP-3440]


[AP-3440]: https://intersticelabs.atlassian.net/browse/AP-3440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AP-3440]: https://intersticelabs.atlassian.net/browse/AP-3440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ