### PR TITLE
[Ap-3443] firewall serialnumber add

### DIFF
--- a/classic/computers/computer_entity.go
+++ b/classic/computers/computer_entity.go
@@ -38,6 +38,7 @@ type Computer struct {
 	ExtensionAttributes []ExtensionAttributes    `json:"extension_attributes"`
 	Groups              GroupInformation         `json:"groups_accounts"`
 	ConfigProfiles      []ConfigProfile          `json:"configuration_profiles"`
+	Security            SecurityInformation      `json:"security,omitempty"`
 }
 
 // GeneralInformation holds basic information associated with Jamf device
@@ -187,4 +188,11 @@ type ConfigProfile struct {
 	Name      string `json:"name"`
 	UUID      string `json:"uuid"`
 	Removable bool   `json:"is_removable"`
+}
+type SecurityInformation struct {
+	ActivationLock      bool   `json:"activation_lock,omitempty"`
+	RecoveryLockEnabled bool   `json:"recovery_lock_enabled,omitempty"`
+	SecureBootLevel     string `json:"secure_boot_level,omitempty"`
+	ExternalBootLevel   string `json:"external_boot_level,omitempty"`
+	FirewallEnabled     bool   `json:"firewall_enabled,omitempty"`
 }


### PR DESCRIPTION
## What does this PR do?

Adds Security Info - Firewall enabled for the api.
## PR Checklist 

Check if Jamf Api client produces firewall_enabled information in Security.

## Related PRs or Issues

